### PR TITLE
Treat null as 'infinite past' in Deck.lastSyncAt

### DIFF
--- a/flutter/lib/models/deck.dart
+++ b/flutter/lib/models/deck.dart
@@ -50,7 +50,7 @@ class Deck implements KeyedListItem, Model {
         snapshotValue['deckType']?.toString()?.toLowerCase(), DeckType.values);
     accepted = snapshotValue['accepted'] ?? false;
     lastSyncAt =
-        DateTime.fromMillisecondsSinceEpoch(snapshotValue['lastSyncAt']);
+        DateTime.fromMillisecondsSinceEpoch(snapshotValue['lastSyncAt'] ?? 0);
     category = snapshotValue['category'];
   }
 


### PR DESCRIPTION
This should have been migrated a long time ago, but apparently
not all database nodes were refreshed.
