### PR TITLE
Use FirebaseAnalytics() instead of a global object

### DIFF
--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:isolate';
 
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_analytics/observer.dart';
 import 'package:firebase_database/firebase_database.dart';
 import 'package:flutter/material.dart';
@@ -8,14 +9,13 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'flutter/localization.dart';
 import 'models/base/transaction.dart';
-import 'remote/analytics.dart';
 import 'remote/error_reporting.dart';
 import 'views/decks_list/decks_list.dart';
 import 'views/helpers/sign_in.dart';
 
 class App extends StatelessWidget {
   static final _analyticsNavigatorObserver =
-      FirebaseAnalyticsObserver(analytics: analytics);
+      FirebaseAnalyticsObserver(analytics: FirebaseAnalytics());
 
   @override
   Widget build(BuildContext context) {
@@ -59,7 +59,7 @@ void main() {
   runZoned<Future>(() async {
     FirebaseDatabase.instance.setPersistenceEnabled(true);
     Transaction.subscribeToOnlineStatus();
-    analytics.logAppOpen();
+    FirebaseAnalytics().logAppOpen();
     runApp(App());
   }, onError: (error, stackTrace) async {
     await ErrorReporting.report('Zone', error, stackTrace);

--- a/flutter/lib/remote/analytics.dart
+++ b/flutter/lib/remote/analytics.dart
@@ -1,3 +1,0 @@
-import 'package:firebase_analytics/firebase_analytics.dart';
-
-final analytics = FirebaseAnalytics();

--- a/flutter/lib/views/deck_sharing/deck_sharing.dart
+++ b/flutter/lib/views/deck_sharing/deck_sharing.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 
 import '../../flutter/localization.dart';
@@ -7,7 +8,6 @@ import '../../flutter/styles.dart';
 import '../../flutter/user_messages.dart';
 import '../../models/deck.dart';
 import '../../models/deck_access.dart';
-import '../../remote/analytics.dart';
 import '../../remote/user_lookup.dart';
 import '../../view_models/deck_access_view_model.dart';
 import '../../views/helpers/slow_operation_widget.dart';
@@ -100,7 +100,7 @@ class _DeckSharingState extends State<DeckSharingPage> {
       } else {
         await DeckAccessesViewModel.shareDeck(
             DeckAccess(deck: widget._deck, uid: uid, access: deckAccess));
-        analytics.logShare(
+        FirebaseAnalytics().logShare(
             contentType: 'application/flashcards-deck',
             itemId: widget._deck.key);
       }

--- a/flutter/lib/views/helpers/sign_in.dart
+++ b/flutter/lib/views/helpers/sign_in.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
@@ -8,7 +9,6 @@ import '../../flutter/styles.dart';
 import '../../models/base/transaction.dart';
 import '../../models/fcm.dart';
 import '../../models/user.dart';
-import '../../remote/analytics.dart';
 import '../../remote/error_reporting.dart';
 import '../../remote/sign_in.dart';
 import 'helper_progress_indicator.dart';
@@ -46,7 +46,7 @@ class _SignInWidgetState extends State<SignInWidget> {
           ..save(User.fromFirebase(firebaseUser))
           ..commit();
 
-        analytics
+        FirebaseAnalytics()
           ..setUserId(_user.uid)
           ..logLogin();
 


### PR DESCRIPTION
FirebaseAnalytics() constructor is a factory method and does not create
a new instance on each call. It is in fact same as
`FirebaseDatabase.instance`, except for different semantics.