### PR TITLE
Wrap watched cards text in SafeArea widget

### DIFF
--- a/flutter/lib/views/cards_learning/cards_learning.dart
+++ b/flutter/lib/views/cards_learning/cards_learning.dart
@@ -91,6 +91,10 @@ class CardsLearningState extends State<CardsLearning> {
                       ),
                       Row(
                         children: <Widget>[
+                          // Use SafeArea to indent the child by the amount
+                          // necessary to avoid The Notch on the iPhone X,
+                          // or other similar creative physical features of
+                          // the display.
                           SafeArea(
                             child: Text(
                               AppLocalizations.of(context)

--- a/flutter/lib/views/cards_learning/cards_learning.dart
+++ b/flutter/lib/views/cards_learning/cards_learning.dart
@@ -91,10 +91,12 @@ class CardsLearningState extends State<CardsLearning> {
                       ),
                       Row(
                         children: <Widget>[
-                          Text(
-                            AppLocalizations.of(context)
-                                .watchedCards(_watchedCount),
-                            style: AppStyles.secondaryText,
+                          SafeArea(
+                            child: Text(
+                              AppLocalizations.of(context)
+                                  .watchedCards(_watchedCount),
+                              style: AppStyles.secondaryText,
+                            ),
                           ),
                         ],
                       )


### PR DESCRIPTION
Before:
<img width="392" alt="screen shot 2018-11-01 at 11 44 19" src="https://user-images.githubusercontent.com/6387464/47847580-f5fe8d80-ddcb-11e8-8eae-e38d19b479e9.png">
After:
<img width="365" alt="screen shot 2018-11-01 at 11 45 10" src="https://user-images.githubusercontent.com/6387464/47847597-fdbe3200-ddcb-11e8-94c2-be8bc777dff6.png">
