### PR TITLE
Delete reportError from UserMessages

### DIFF
--- a/flutter/lib/flutter/user_messages.dart
+++ b/flutter/lib/flutter/user_messages.dart
@@ -9,8 +9,7 @@ class UserMessages {
   // TODO(ksheremet): Get rid of it
   static Future<void> showError(ScaffoldState scaffoldFinder(), e,
       [StackTrace stackTrace]) {
-    var errorFuture =
-        ErrorReporting.report('showError', e, stackTrace ?? StackTrace.current);
+    var errorFuture = ErrorReporting.report('showError', e, stackTrace);
 
     // Call a finder only *after* reporting the error, in case it crashes
     // (often because Scaffold.of cannot find Scaffold ancestor widget).
@@ -20,11 +19,6 @@ class UserMessages {
     showMessage(scaffoldState, message);
 
     return errorFuture;
-  }
-
-  // TODO(ksheremet): Get rid of it
-  static void reportError(e, [StackTrace stackTrace]) {
-    ErrorReporting.report('showError', e, stackTrace ?? StackTrace.current);
   }
 
   // TODO(ksheremet): Add user message for Snackbar and error message for

--- a/flutter/lib/remote/error_reporting.dart
+++ b/flutter/lib/remote/error_reporting.dart
@@ -29,6 +29,7 @@ class ErrorReporting {
     if (stackTrace == null && error is Error) {
       stackTrace = error.stackTrace;
     }
+    stackTrace ??= StackTrace.current;
 
     if (_sentry == null) {
       var environment = 'production';

--- a/flutter/lib/view_models/card_create_update_bloc.dart
+++ b/flutter/lib/view_models/card_create_update_bloc.dart
@@ -122,7 +122,7 @@ class CardCreateUpdateBloc {
         _onCardAddedController.add(locale.cardAddedUserMessage);
       }
     } catch (e, stackTrace) {
-      ErrorReporting.report('saveCard', e, stackTrace ?? StackTrace.current);
+      ErrorReporting.report('saveCard', e, stackTrace);
       _onErrorController
           .add(UserMessages.formUserFriendlyErrorMessage(locale, e));
     }

--- a/flutter/lib/view_models/deck_settings_bloc.dart
+++ b/flutter/lib/view_models/deck_settings_bloc.dart
@@ -86,7 +86,7 @@ class DeckSettingsBloc extends ScreenBloc {
       await _save();
       return true;
     } catch (e, stackTrace) {
-      ErrorReporting.report('updateDeck', e, stackTrace ?? StackTrace.current);
+      ErrorReporting.report('updateDeck', e, stackTrace);
       notifyErrorOccurred(e);
     }
     return false;
@@ -98,8 +98,7 @@ class DeckSettingsBloc extends ScreenBloc {
         await _delete();
         notifyPop();
       } catch (e, stackTrace) {
-        ErrorReporting.report(
-            'deleteCard', e, stackTrace ?? StackTrace.current);
+        ErrorReporting.report('deleteCard', e, stackTrace);
         super.notifyErrorOccurred(e);
       }
     });

--- a/flutter/lib/views/deck_sharing/deck_sharing.dart
+++ b/flutter/lib/views/deck_sharing/deck_sharing.dart
@@ -6,6 +6,7 @@ import 'package:delern_flutter/flutter/styles.dart';
 import 'package:delern_flutter/flutter/user_messages.dart';
 import 'package:delern_flutter/models/deck_access_model.dart';
 import 'package:delern_flutter/models/deck_model.dart';
+import 'package:delern_flutter/remote/error_reporting.dart';
 import 'package:delern_flutter/remote/user_lookup.dart';
 import 'package:delern_flutter/view_models/deck_access_view_model.dart';
 import 'package:delern_flutter/views/deck_sharing/deck_access_dropdown.dart';
@@ -88,7 +89,6 @@ class _DeckSharingState extends State<DeckSharing> {
   bool _isEmailCorrect() => _textController.text.contains('@');
 
   Future<void> _shareDeck(AccessType deckAccess, BuildContext context) async {
-    print('Share deck: $deckAccess: ${_textController.text}');
     try {
       var uid = await userLookup(_textController.text.toString());
       if (uid == null) {
@@ -109,7 +109,7 @@ class _DeckSharingState extends State<DeckSharing> {
       UserMessages.showMessage(Scaffold.of(context),
           AppLocalizations.of(context).offlineUserMessage);
     } on HttpException catch (e, stackTrace) {
-      UserMessages.reportError(e, stackTrace);
+      ErrorReporting.report('share deck', e, stackTrace);
       UserMessages.showMessage(Scaffold.of(context),
           AppLocalizations.of(context).serverUnavailableUserMessage);
     } catch (e, stackTrace) {


### PR DESCRIPTION
This methode was used only one time in DeckSettings. It
can be replaced on ErrorReporing.report