### PR TITLE
Update Firebase plugins to migrate to AndroidX

### DIFF
--- a/flutter/android/app/build.gradle
+++ b/flutter/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -50,7 +50,7 @@ android {
         targetSdkVersion 27
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {
@@ -72,8 +72,8 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.1.2-alpha01'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.2-alpha01'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.google.gms:google-services:3.1.2'
     }
 }

--- a/flutter/android/gradle.properties
+++ b/flutter/android/gradle.properties
@@ -1,3 +1,5 @@
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M
 
 # Enable next-generation Dex Compiler.

--- a/flutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 28 10:02:53 CET 2018
+#Thu Mar 07 16:42:51 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/flutter/ios/Podfile.lock
+++ b/flutter/ios/Podfile.lock
@@ -186,7 +186,7 @@ SPEC CHECKSUMS:
   device_info: 3ebad48f726348f69abd802f3334a8d1ed795fbd
   Firebase: 8bb9268bff82374f2cbaaabb143e725743c316ae
   firebase_analytics: bd50d8f5d3f42dcab6da67944a849062470b0a19
-  firebase_auth: 6023fc2e28feabd6571d9a105b678cce7978be90
+  firebase_auth: 02ced56521bc9f220d40edda27b1ec5a2fcdf01e
   firebase_core: ce5006bb48508ee4e71e0f429a3f519bb8ee2961
   firebase_database: 99b15d6a0536ee969200b6eaf69bcd0b15b7b114
   firebase_messaging: b25b2fa94e685146bcf9d706ed87b4e95cd2a17d

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       name: device_info
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.0+1"
   file:
     dependency: transitive
     description:
@@ -98,35 +98,35 @@ packages:
       name: firebase_analytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0+1"
+    version: "2.0.3"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.0"
+    version: "0.8.1+4"
   firebase_core:
     dependency: transitive
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5+1"
+    version: "0.3.1+1"
   firebase_database:
     dependency: "direct main"
     description:
       name: firebase_database
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0+1"
+    version: "2.0.2"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0+1"
+    version: "4.0.0+1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -179,21 +179,21 @@ packages:
       name: google_sign_in
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.0+1"
+    version: "4.0.1+1"
   html:
     dependency: transitive
     description:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3+3"
+    version: "0.13.4+1"
   http:
     dependency: "direct main"
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+17"
+    version: "0.12.0+1"
   http_multi_server:
     dependency: transitive
     description:
@@ -335,7 +335,7 @@ packages:
       name: package_info
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.2+1"
+    version: "0.4.0+1"
   package_resolver:
     dependency: transitive
     description:
@@ -419,14 +419,14 @@ packages:
       name: share
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.3"
+    version: "0.6.0+1"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.5.1+1"
   shelf:
     dependency: transitive
     description:
@@ -543,7 +543,7 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.3"
+    version: "5.0.1"
   usage:
     dependency: transitive
     description:
@@ -595,4 +595,4 @@ packages:
     version: "2.1.15"
 sdks:
   dart: ">=2.1.0 <2.3.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=0.5.6 <2.0.0"

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -8,26 +8,26 @@ description: Spaced repetition learning system (Flutter version)
 version: 1.0.0+1
 
 dependencies:
-  device_info: ^0.3.0
-  package_info: ^0.3.2
-  url_launcher: ^3.0.3
+  device_info: ^0.4.0
+  package_info: ^0.4.0
+  url_launcher: ^5.0.1
   flutter_markdown: ^0.2.0
-  http: ^0.11.3
-  share: ^0.5.2
-  sentry: ^2.1.1
-  shared_preferences: ^0.4.3
-  intro_views_flutter: ^2.2.4
+  http: ^0.12.0
+  share: ^0.6.0
+  sentry: ^2.2.0
+  shared_preferences: ^0.5.1
+  intro_views_flutter: ^2.4.0
   quiver: '>=2.0.0 <3.0.0'
   observable:  #^0.22.1+5
     git:
       url: https://github.com/dotdoom/observable.git
       ref: list-observed-unobserved
 
-  firebase_auth: ^0.7.0
-  firebase_analytics: ^1.0.6
-  firebase_database: ^1.0.5
-  firebase_messaging: ^2.1.0
-  google_sign_in: ^3.2.4
+  firebase_auth: ^0.8.1
+  firebase_analytics: ^2.0.3
+  firebase_database: ^2.0.2
+  firebase_messaging: ^4.0.0
+  google_sign_in: ^4.0.1
 
   flutter:
     sdk: flutter
@@ -42,7 +42,7 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
 
-  intl_translation: ^0.17.0
+  intl_translation: ^0.17.3
   mockito: ^3.0.0
 
 


### PR DESCRIPTION
Fixes #954.

List of updates, with links to changelogs and important highlights:

* com.android.tools.build:gradle (3.2.1 -> 3.3.2). Changelog:
  https://developer.android.com/studio/releases/gradle-plugin#3-3-0
  - the plugin now uses R8 instead of ProGuard to shrink and obfuscate;
  - automatic downloading of missing SDK packages: support NDK.

* Gradle (4.10 -> 4.10.1). Changelog:
  https://docs.gradle.org/4.10.1/release-notes.html
  - incremental Java compiler, now enabled by default;
  - Gradle will now periodically clean up unused /caches.

* sentry (2.1.1 -> 2.2.0). Changelog:
  https://pub.dartlang.org/packages/sentry#-changelog-tab-
  - add a stackFrameFilter argument to SentryClient's capture.

* url_launcher (3.0.3 -> 5.0.1). Changelog:
  https://pub.dartlang.org/packages/url_launcher#-changelog-tab-
  - add enableJavaScript, closeWebView, universalLinksOnly parameters;
  - updated launch to return Future<bool> (relevant only for
    universalLinksOnly = true, which we don't use);
  - update to AndroidX.

---

The following upgrades do not contain any significant changes, apart
from migrating Android codebase to AndroidX:

* firebase_database (1.1.0+1 -> 2.0.2). Changelog:
  https://pub.dartlang.org/packages/firebase_database#-changelog-tab-

* firebase_core (0.2.5+1 -> 0.3.1+1). Changelog:
  https://pub.dartlang.org/packages/firebase_core#-changelog-tab-

* device_info (0.3.0 -> 0.4.0+1). Changelog:
  https://pub.dartlang.org/packages/device_info#-changelog-tab-

* firebase_analytics (1.2.0+1 -> 2.0.3). Changelog:
  https://pub.dartlang.org/packages/firebase_analytics#-changelog-tab-

* firebase_auth (0.7.0 -> 0.8.1+4). Changelog:
  https://pub.dartlang.org/packages/firebase_auth#-changelog-tab-

* firebase_messaging (2.2.0+ 1-> 4.0.0+1). Changelog:
  https://pub.dartlang.org/packages/firebase_messaging#-changelog-tab-

* google_sign_in (3.3.0+1 -> 4.0.1+1). Changelog:
  https://pub.dartlang.org/packages/google_sign_in#-changelog-tab-

* share (0.5.3 -> 0.6.0+1). Changelog:
  https://pub.dartlang.org/packages/share#-changelog-tab-

* shared_preferences (0.4.3 -> 0.5.1+1). Changelog:
  https://pub.dartlang.org/packages/shared_preferences#-changelog-tab-