### PR TITLE
Fix tests on iOS

### DIFF
--- a/flutter/lib/views/helpers/sign_in_widget.dart
+++ b/flutter/lib/views/helpers/sign_in_widget.dart
@@ -50,15 +50,9 @@ class _SignInWidgetState extends State<SignInWidget> {
           (Transaction()..save(fcm)).commit();
         });
 
-        // Notifications permission dialog on iOS is definitive: if the user
-        // declines, there's no way to ask confirmation again.
-        // TODO(dotdoom): avoid asking when the app installs (useless).
-        // TODO(dotdoom): present a custom dialog first, and then iOS.
-        _firebaseMessaging
-          ..requestNotificationPermissions()
-          // TODO(dotdoom): register onMessage to show a snack bar with
-          //                notification when the app is in foreground.
-          ..configure();
+        // TODO(dotdoom): register onMessage to show a snack bar with
+        //                notification when the app is in foreground.
+        _firebaseMessaging.configure();
       }
     });
 

--- a/flutter/test_driver/main.dart
+++ b/flutter/test_driver/main.dart
@@ -1,10 +1,12 @@
 import 'package:delern_flutter/main.dart' as app;
+import 'package:delern_flutter/remote/auth.dart';
 import 'package:flutter_driver/driver_extension.dart';
 
-void main() {
+void main() async {
   // This line enables the extension
   enableFlutterDriverExtension();
-
+  // Sign out before running tests to clear cached data
+  await Auth.instance.signOut();
   // Call the `main()` of your app or call `runApp` with whatever widget
   // you are interested in testing.
   app.main();

--- a/flutter/test_driver/main_test.dart
+++ b/flutter/test_driver/main_test.dart
@@ -39,7 +39,10 @@ void main() {
       await driver.waitFor(add);
       await driver.enterText('My Test Deck');
       await driver.waitFor(find.text('My Test Deck'));
-      await driver.tap(add);
+      // When text was entered business logic needs some time to enable
+      // "Add" button. Otherwise disabled button will be clicked and test fails.
+      await Future.delayed(const Duration(seconds: 1));
+      await driver.tap(add, timeout: timeoutDuration);
     });
 
     test('create_card', () async {


### PR DESCRIPTION
- Disable Notifications permission screen, because users
always tap don't allow and screen breaks tests
- Always sign out before running tests, in case of some
cached data