### PR TITLE
Revert "Use default Material Design colors"

### DIFF
--- a/flutter/lib/flutter/styles.dart
+++ b/flutter/lib/flutter/styles.dart
@@ -23,15 +23,18 @@ final Color signInBackgroundColor = Colors.greenAccent[100];
 const TextStyle primaryText = TextStyle(
   fontSize: 19,
   fontWeight: FontWeight.w400,
+  color: Colors.black,
 );
 
 const TextStyle secondaryText = TextStyle(
   fontSize: 16,
   fontWeight: FontWeight.w400,
+  color: Colors.black87,
 );
 
-const TextStyle navigationDrawerGroupText = TextStyle(
+final TextStyle navigationDrawerGroupText = TextStyle(
   fontWeight: FontWeight.w600,
+  color: Colors.grey[600],
 );
 
 const TextStyle searchBarText = TextStyle(


### PR DESCRIPTION
This reverts commit e1db79f4725096d70b3f8b27d35837b4ebdc4369.
Use presetup colors in styles, otherwise default color for markdown is
white, which is invisible on the light-green background of card

Before
![Screenshot_1560247156](https://user-images.githubusercontent.com/6387464/59262898-6a41bf00-8c40-11e9-91e6-ed576ff9bdcb.png)


Now:
![Screenshot_1560247032](https://user-images.githubusercontent.com/6387464/59262821-42eaf200-8c40-11e9-9d45-5ec0e6e90166.png)