### PR TITLE
Enable leading in SearchBarWidget, use new icon for Drawer

### DIFF
--- a/flutter/lib/views/decks_list/decks_list.dart
+++ b/flutter/lib/views/decks_list/decks_list.dart
@@ -128,7 +128,7 @@ class _DecksListState extends State<DecksList> {
           title: localizations.of(context).listOFDecksScreenTitle,
           search: setFilter,
           leading: IconButton(
-            icon: Icon(Icons.person),
+            icon: const Icon(Icons.person),
             onPressed: () {
               _scaffoldKey.currentState.openDrawer();
             },

--- a/flutter/lib/views/decks_list/decks_list.dart
+++ b/flutter/lib/views/decks_list/decks_list.dart
@@ -119,12 +119,21 @@ class _DecksListState extends State<DecksList> {
   }
 
   GlobalKey fabKey = GlobalKey();
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
   @override
   Widget build(BuildContext context) => Scaffold(
+        key: _scaffoldKey,
         appBar: SearchBarWidget(
-            title: localizations.of(context).listOFDecksScreenTitle,
-            search: setFilter),
+          title: localizations.of(context).listOFDecksScreenTitle,
+          search: setFilter,
+          leading: IconButton(
+            icon: Icon(Icons.person),
+            onPressed: () {
+              _scaffoldKey.currentState.openDrawer();
+            },
+          ),
+        ),
         drawer: NavigationDrawer(),
         body: Column(
           children: <Widget>[

--- a/flutter/lib/views/helpers/search_bar_widget.dart
+++ b/flutter/lib/views/helpers/search_bar_widget.dart
@@ -7,8 +7,9 @@ typedef SearchCallback = void Function(String input);
 class SearchBarWidget extends StatefulWidget implements PreferredSizeWidget {
   final String title;
   final SearchCallback search;
+  final Widget leading;
 
-  const SearchBarWidget({this.title, this.search});
+  const SearchBarWidget({this.title, this.search, this.leading});
 
   @override
   State<StatefulWidget> createState() => SearchBarWidgetState();
@@ -68,6 +69,7 @@ class SearchBarWidgetState extends State<SearchBarWidget> {
 
     return AppBar(
       title: appBarTitle,
+      leading: widget.leading,
       actions: <Widget>[
         IconButton(
           icon: actionIcon,


### PR DESCRIPTION
Fixes #1055

![Screenshot_1560351434](https://user-images.githubusercontent.com/6387464/59362093-2f6c8380-8d33-11e9-9790-3e9e9bfd6702.png)

@Kateevp 
I've taken the default profile icon from the Flutter framework. What do you think?