### PR TITLE
Show cursor in search bar (ios)

### DIFF
--- a/flutter/lib/views/helpers/search_bar_widget.dart
+++ b/flutter/lib/views/helpers/search_bar_widget.dart
@@ -56,6 +56,8 @@ class SearchBarWidgetState extends State<SearchBarWidget> {
       actionIcon = const Icon(Icons.close);
       appBarTitle = TextField(
         autofocus: true,
+        showCursor: true,
+        cursorColor: Theme.of(context).cursorColor,
         controller: _searchController,
         style: app_styles.searchBarText,
         decoration: InputDecoration(


### PR DESCRIPTION
Fixes #1177

By default for iOS, it takes Primary Color, which is the color of the toolbar. Therefore cursor was not visible