### PR TITLE
Fix empty Deck Name

### DIFF
--- a/flutter/lib/l10n/app_localizations.dart
+++ b/flutter/lib/l10n/app_localizations.dart
@@ -92,6 +92,12 @@ class AppLocalizations {
         desc: 'User can edit a deck',
       );
 
+  String get emptyDeck => Intl.message(
+        'Deck Value Can\'t Be Empty',
+        name: 'emptyDeck',
+        desc: 'Deck Value Can\'t Be Empty',
+      );
+
   String get canView => Intl.message(
         'Can View',
         name: 'canView',

--- a/flutter/lib/views/edit_deck/edit_deck.dart
+++ b/flutter/lib/views/edit_deck/edit_deck.dart
@@ -45,6 +45,7 @@ class _EditDeckState extends State<EditDeck> {
   final TextEditingController _deckNameController = TextEditingController();
   DeckModel _currentDeckState;
   GlobalKey fabKey = GlobalKey();
+  bool _emptyDeckCheck = false;
 
   void _searchTextChanged(EditDeckBloc bloc, String input) {
     if (input == null) {
@@ -81,13 +82,13 @@ class _EditDeckState extends State<EditDeck> {
             cardKey: card.key,
           );
         });
-
         return bloc;
       },
       appBarBuilder: (bloc) => SearchBarWidget(
         title: localizations.of(context).edit,
         search: (input) => _searchTextChanged(bloc, input),
         actions: _buildActions(bloc),
+        leading: _emptyDeckCheck ? Container() : null,
       ),
       bodyBuilder: (bloc) => Column(
         children: <Widget>[
@@ -125,11 +126,13 @@ class _EditDeckState extends State<EditDeck> {
   Widget _buildEditDeck(EditDeckBloc bloc) => TextField(
         textAlign: TextAlign.center,
         decoration: InputDecoration(
-          border: InputBorder.none,
+          border: _emptyDeckCheck ? null : InputBorder.none,
           suffixIcon: const Icon(Icons.edit),
           // We'd like to center text. Because of suffixIcon, the text
           // is placed a little bit to the left. To fix this problem, we
           // add an empty Container with size of Icon to the left.
+          errorText:
+              _emptyDeckCheck ? localizations.of(context).emptyDeck : null,
           prefixIcon: Container(
             height: IconTheme.of(context).size,
             width: IconTheme.of(context).size,
@@ -139,7 +142,17 @@ class _EditDeckState extends State<EditDeck> {
         keyboardType: TextInputType.multiline,
         controller: _deckNameController,
         style: app_styles.editDeckText,
-        onChanged: bloc.onDeckName.add,
+        onChanged: (text) {
+          bloc.onDeckName.add(text);
+          if (_deckNameController.text.isEmpty) {
+            setState(() {
+              _emptyDeckCheck = true;
+            });
+          } else {
+            _emptyDeckCheck = false;
+            bloc.onDeckName.add(text);
+          }
+        },
       );
 
   Widget _buildCardsInDeck(EditDeckBloc bloc) =>


### PR DESCRIPTION
@ksheremet
Resolved the conflicts
I have fixed the empty Deck Name, I have also added couple of below listed check withe empty Deck Name check.

1. If the Deck Name is empty it will display a errorText.
2. It also change the border of the textfield to InputBorder.none ,which gives a effect that the textfield is empty.
3. Also if the textfield is empty the back button is hidden and vice versa.
4. I have stored the error test message in AppLocalizations

Please ignore/close the Fix empty Deck Name #1201 pull request