### PR TITLE
Use ValueNotifier for card's first flip

### DIFF
--- a/flutter/lib/views/cards_interval_learning/cards_interval_learning.dart
+++ b/flutter/lib/views/cards_interval_learning/cards_interval_learning.dart
@@ -142,9 +142,7 @@ class CardsIntervalLearningState extends State<CardsIntervalLearning> {
                             back: card.back,
                             colors:
                                 specifyCardColors(_deck.value.type, card.back),
-                            onFirstFlip: () {
-                              _showReplyButtons.value = true;
-                            },
+                            hasBeenFlipped: _showReplyButtons,
                             key: ValueKey(card.key),
                           );
                         }),
@@ -210,8 +208,6 @@ class CardsIntervalLearningState extends State<CardsIntervalLearning> {
     // We call setState because the next card has arrived and we have to
     // display it.
     setState(() {
-      // New card arrived, do not show reply buttons.
-      _showReplyButtons.value = false;
       _scheduledCard = scheduledCard;
       _card = _deck.value.cards.getItem(scheduledCard.key);
     });

--- a/flutter/test/flip_card_widget_test.dart
+++ b/flutter/test/flip_card_widget_test.dart
@@ -9,7 +9,7 @@ void main() {
   testWidgets('Flip card', (tester) async {
     const frontSide = 'der Vater';
     const backSide = 'father';
-    var _wasFlipped = false;
+    final hasBeenFlipped = ValueNotifier<bool>(null);
 
     // Widget must be wrapped in MaterialApp widget because it uses material
     // related classes.
@@ -21,21 +21,19 @@ void main() {
         front: frontSide,
         back: backSide,
         colors: app_styles.cardBackgroundColors[Gender.masculine],
-        onFirstFlip: () {
-          _wasFlipped = true;
-        },
+        hasBeenFlipped: hasBeenFlipped,
         key: UniqueKey(),
       ),
     ));
     await tester.pumpAndSettle();
     _expectText(tester.allWidgets, frontSide);
     // Back side wasn't showed
-    assert(!_wasFlipped);
+    assert(hasBeenFlipped.value == false);
     await tester.tap(find.byType(Card));
     await tester.pumpAndSettle();
     _expectText(tester.allWidgets, backSide);
-    // Back side was showed
-    assert(_wasFlipped);
+    // Back side has been shown.
+    assert(hasBeenFlipped.value == true);
   });
 }
 


### PR DESCRIPTION
The idea is still to discard the state of FlipCardWidget when a new card
arrives, but also let it control the value for hasBeenFlipped notifier,
starting from `initState()`.