### PR TITLE
Start multiline strings with a newline

### DIFF
--- a/flutter/analysis_options.autogen.yaml
+++ b/flutter/analysis_options.autogen.yaml
@@ -68,6 +68,7 @@ linter:
     - invariant_booleans
     - iterable_contains_unrelated_type
     - join_return_with_assignment
+    - leading_newlines_in_multiline_strings
     - library_names
     - library_prefixes
     - lines_longer_than_80_chars

--- a/flutter/lib/l10n/app_localizations.dart
+++ b/flutter/lib/l10n/app_localizations.dart
@@ -208,7 +208,8 @@ class AppLocalizations {
       );
 
   String get inviteToAppMessage => Intl.message(
-        '''I invite you to install Delern, a spaced repetition learning app, which will allow you to learn quickly and easily!
+        '''
+I invite you to install Delern, a spaced repetition learning app, which will allow you to learn quickly and easily!
 
 Proceed to install it from:
 Google Play: https://play.google.com/store/apps/details?id=org.dasfoo.delern


### PR DESCRIPTION
https://dart-lang.github.io/linter/lints/leading_newlines_in_multiline_strings.html
Multiline strings are easier to read when they start with a newline (a newline
starting a multiline string is ignored).