### PR TITLE
Remove linter version heuristics

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,38 +5,13 @@ end
 lane :update_analysis_options do
   # TODO(dotdoom): move into fastlane-flutter plugin.
 
-  # Dragons ahead!
-  # This is a terrible hack using some fragile assumptions, but this is a
-  # concious decision which keeps the application build reliable.
-
-  # Extract Dart build commit hash (assuming it's present) from a string like
-  # "Dart 2.8.0 (build 2.8.0-dev.5.0 fc3af737c7)".
-  unless flutter(args: %w(--version), capture_stdout: true)
-    .lines
-    .grep(/Dart/)
-    .first =~ /[(]build .* (.*)[)]/
-    UI.abort_with_message!('Unable to parse "flutter --version" output.')
-  end
-  pinned_sdk_deps = "https://raw.githubusercontent.com/dart-lang/sdk/#$1/DEPS"
-
-  # Extract linter version from a file which has something like
-  #   "linter_tag": "0.1.7",
-  fastlane_require 'open-uri'
-  linter_version = open(pinned_sdk_deps)
-    .lines
-    .grep(/"linter_tag":/)
-    .first
-    .split('"')[3]
-  # Make an assumption that a linter version is also a tag in its GitHub repo.
-  # TODO(dotdoom): speculate less here and actually use "flutter pub pub get".
-  linter_root_uri =
-    "https://raw.githubusercontent.com/dart-lang/linter/#{linter_version}"
-
   File.write(
     '../flutter/analysis_options.autogen.yaml',
     <<-YAML)
 include: package:flutter/analysis_options_user.yaml
-#{open("#{linter_root_uri}/example/all.yaml").read}
+#{open(
+  'https://raw.githubusercontent.com/dart-lang/linter/master/example/all.yaml'
+).read}
   YAML
 end
 

--- a/flutter/analysis_options.autogen.yaml
+++ b/flutter/analysis_options.autogen.yaml
@@ -61,6 +61,7 @@ linter:
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
+    - exhaustive_cases
     - file_names
     - flutter_style_todos
     - hash_and_equals
@@ -76,6 +77,7 @@ linter:
     - literal_only_boolean_expressions
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
+    - no_default_cases
     - no_duplicate_case_values
     - no_logic_in_create_state
     - no_runtimeType_toString
@@ -130,6 +132,7 @@ linter:
     - provide_deprecation_message
     - public_member_api_docs
     - recursive_getters
+    - sized_box_for_whitespace
     - slash_for_doc_comments
     - sort_child_properties_last
     - sort_constructors_first
@@ -160,6 +163,7 @@ linter:
     - unsafe_html
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
+    - use_is_even_rather_than_modulo
     - use_key_in_widget_constructors
     - use_raw_strings
     - use_rethrow_when_possible


### PR DESCRIPTION
Since Dart shipped with Flutter no longer shows the real VM version,
this mechanism doesn't work.

Dart "2.8.0" (current output of `flutter --version`) is nowhere to be found in
https://github.com/dart-lang/linter/blob/master/tool/since/dart_sdk.yaml